### PR TITLE
Add Pi's `AGENTS.md` and the Vouch contributor management system

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ A list of policies by different open source projects about how to engage with AI
 - [scikit-learn's AGENTS.md file](https://github.com/scikit-learn/scikit-learn/blob/main/AGENTS.md)
 - [agentic-oss-policy: Policy templates for protecting open source projects from autonomous AI agent abuse](https://github.com/guenp/agentic-oss-policy)
 - [llama.cpp AGENTS.md file](https://github.com/ggml-org/llama.cpp/blob/master/AGENTS.md#instructions-for-llamacpp)
+- [Pi (AI agent toolkit) – AGENTS.md file](https://github.com/badlogic/pi-mono/blob/4ba3e5be229a570187d8efbef5c14c0d5ce40dcc/AGENTS.md)
+- [The "Vouch" system for managing trust in contributions](https://github.com/mitchellh/vouch)
 
 ## Acknowledgements
 


### PR DESCRIPTION
Thanks for starting this, Melissa 💜

This PR adds Pi – interesting because of Vouch, and Vouch itself (now in use by Ghostty).