### PR TITLE
add icechunk to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A list of policies by different open source projects about how to engage with AI
 - [Ghostty](https://ghostty.org/): [AI Usage Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md)
 - [goose](https://github.com/block/goose): [How to Use AI with goose](https://github.com/block/goose/blob/main/HOWTOAI.md), [AGENTS.md file](https://github.com/block/goose/blob/main/AGENTS.md), [copilot-instructions.md file](https://github.com/block/goose/blob/main/.github/copilot-instructions.md)
 - [Homebrew](https://github.com/Homebrew/brew/tree/main): [(AI/LLM) usage](https://github.com/Homebrew/brew/blob/main/CONTRIBUTING.md#artificial-intelligencelarge-language-model-aillm-usage)
-- [Icechunk](https://icechunk.io/en/latest/): [AI Usage/Contribution Policy](https://icechunk.io/en/latest/ai-policy/)
+- [Icechunk](https://icechunk.io/en/latest/): No disclosure required - norms for code responsibility and communication [AI Usage/Contribution Policy](https://icechunk.io/en/latest/ai-policy/)
 - [IREE (Intermediate Representation Execution Environment)](https://iree.dev/): [AI tool use](https://iree.dev/developers/general/contributing/#ai-tool-use)
 - [Jellyfin](https://jellyfin.org/): [Jellyfin LLM/"AI" Development Policy](https://jellyfin.org/docs/general/contributing/llm-policies/)
 - [Kornia](https://github.com/kornia/kornia/tree/main) : [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md)


### PR DESCRIPTION
I put in the allow section. One thing maybe somewhat of note is that we don't require disclosure of AI assistance which most of these seem to do. Not sure if thats worth calling out somehow - maybe the allow section split into "disclosure required" vs not?

https://icechunk.io/en/latest/ai-policy/

Also thank you @melissawm for compiling this. I found it to be a very helpful resource when I drafted our policy.