### PR TITLE
Add SciActive Human Contribution Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A list of policies by different open source projects about how to engage with AI
 - [SDL](https://libsdl.org/): [PR Template](https://github.com/libsdl-org/SDL/blob/main/.github/PULL_REQUEST_TEMPLATE.md), [AGENTS.md file](https://github.com/libsdl-org/SDL/blob/main/AGENTS.md)
 - [Servo](https://servo.org): [AI Contributions](https://book.servo.org/contributing/getting-started.html#ai-contributions)
 - [Zig](https://ziglang.org): [Strict No LLM / No AI Policy](https://ziglang.org/code-of-conduct/#strict-no-llm-no-ai-policy)
+- [SciActive](https://sciactive.com): [Human Contribution Policy](https://sciactive.com/human-contribution-policy/)
 
 ## Ongoing discussions
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ A list of policies by different open source projects about how to engage with AI
 - [postmarketOS](https://postmarketos.org): [AI Policy](https://docs.postmarketos.org/policies-and-processes/development/ai-policy.html)
 - [QEMU](https://www.qemu.org): [Use of AI-generated content](https://www.qemu.org/docs/master/devel/code-provenance.html#use-of-ai-generated-content)
 - [Redox OS](https://www.redox-os.org/): [AI Policy](https://gitlab.redox-os.org/redox-os/redox/-/blob/master/CONTRIBUTING.md#ai-policy)
+- [SciActive](https://sciactive.com): [Human Contribution Policy](https://sciactive.com/human-contribution-policy/)
 - [SDL](https://libsdl.org/): [PR Template](https://github.com/libsdl-org/SDL/blob/main/.github/PULL_REQUEST_TEMPLATE.md), [AGENTS.md file](https://github.com/libsdl-org/SDL/blob/main/AGENTS.md)
 - [Servo](https://servo.org): [AI Contributions](https://book.servo.org/contributing/getting-started.html#ai-contributions)
 - [Zig](https://ziglang.org): [Strict No LLM / No AI Policy](https://ziglang.org/code-of-conduct/#strict-no-llm-no-ai-policy)
-- [SciActive](https://sciactive.com): [Human Contribution Policy](https://sciactive.com/human-contribution-policy/)
 
 ## Ongoing discussions
 


### PR DESCRIPTION
fixes #55 

There was suggestion to keep in `General Policies` , but i think we can keep in projects rejecting ai contribution .
@hperrin thanks for the issue 😊 
