### PR TITLE
Add no-ai-marks to other references

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Project | Policy link | AI/LLMs allowed? | Disclosure required? | Policy include
 - [Responsible AI Guide](https://responsibleai.guide/)
 - [Let's talk about AI slop](https://archestra.ai/blog/only-responsible-ai)
 - [Scientific Python](https://scientific-python.org): [Blog post: Community Considerations Around AI Contributions](https://blog.scientific-python.org/scientific-python/community-considerations-around-ai/)
+- [no-ai-marks: CI check and pre-commit hooks that fail on AI attribution and hidden Unicode watermarks in commits, PRs, branch names, and files](https://github.com/mishan/no-ai-marks)
 
 ## Acknowledgements
 


### PR DESCRIPTION
Adds [no-ai-marks](https://github.com/mishan/no-ai-marks) to "Other references".

Note: I'm the author. It's a CI check (GitHub Action) and a pair of pre-commit hooks for projects whose policy doesn't allow AI attribution. It fails when commits, PR titles and bodies, branch names, or changed files carry things like `Co-authored-by`/`Assisted-by` trailers crediting AI tools, "Generated with ..." footers, AI bot author identities, agent branch prefixes, or hidden Unicode (zero-width, bidi, tag characters). It only looks for explicit markers and doesn't try to guess whether code was machine-written.

Several of the policies listed here (attrs' "No LLM bots in Co-authored-by:s", for example) are the kind of rule it's meant to enforce, so I thought it might be a useful reference next to Vouch and Good Egg.
